### PR TITLE
reset python GPU build workdir

### DIFF
--- a/python/base-gpu/3.10/Dockerfile
+++ b/python/base-gpu/3.10/Dockerfile
@@ -45,8 +45,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
   mamba clean --all -f -y
 
-WORKDIR /tmp
-
 RUN wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb && \
   dpkg -i cuda-keyring_1.0-1_all.deb
 
@@ -82,3 +80,5 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_DIR/lib/:$CUDNN_PATH/lib \
 
 # Overwrite the base run.sh to include `mamba` usage
 COPY run.sh /usr/local/bin
+
+WORKDIR /etc/noteable/project

--- a/python/base-gpu/3.11/Dockerfile
+++ b/python/base-gpu/3.11/Dockerfile
@@ -45,8 +45,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
   mamba clean --all -f -y
 
-WORKDIR /tmp
-
 RUN wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb && \
   dpkg -i cuda-keyring_1.0-1_all.deb
 
@@ -82,3 +80,5 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_DIR/lib/:$CUDNN_PATH/lib \
 
 # Overwrite the base run.sh to include `mamba` usage
 COPY run.sh /usr/local/bin
+
+WORKDIR /etc/noteable/project

--- a/python/base-gpu/3.9/Dockerfile
+++ b/python/base-gpu/3.9/Dockerfile
@@ -45,8 +45,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
   mamba clean --all -f -y
 
-WORKDIR /tmp
-
 RUN wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb && \
   dpkg -i cuda-keyring_1.0-1_all.deb
 
@@ -82,3 +80,5 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_DIR/lib/:$CUDNN_PATH/lib \
 
 # Overwrite the base run.sh to include `mamba` usage
 COPY run.sh /usr/local/bin
+
+WORKDIR /etc/noteable/project


### PR DESCRIPTION
Mistakenly left as `/tmp`, this sets it back to the `base` builds' `/etc/noteable/project`