### PR TITLE
install packages with `noteable` user

### DIFF
--- a/python/noteable/3.10/Dockerfile
+++ b/python/noteable/3.10/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update -y && \
 COPY Aptfile .
 RUN /usr/bin/apt-install Aptfile
 
+USER noteable
+
 COPY requirements.txt /tmp/noteable_requirements.txt
 RUN pip install --no-cache-dir -r /tmp/noteable_requirements.txt
 
@@ -34,8 +36,6 @@ COPY .pythonrc /srv/noteable/.
 COPY ipython_config.py /etc/ipython
 COPY git_credential_helper.py /git_credential_helper.py
 COPY git-wrapper.sh /usr/local/bin/git
-
-USER noteable
 
 # hadolint ignore=DL3006
 FROM main as gpu

--- a/python/noteable/3.9/Dockerfile
+++ b/python/noteable/3.9/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update -y && \
 COPY Aptfile .
 RUN /usr/bin/apt-install Aptfile
 
+USER noteable
+
 COPY requirements.txt /tmp/noteable_requirements.txt
 RUN pip install --no-cache-dir -r /tmp/noteable_requirements.txt
 
@@ -34,8 +36,6 @@ COPY .pythonrc /srv/noteable/.
 COPY ipython_config.py /etc/ipython
 COPY git_credential_helper.py /git_credential_helper.py
 COPY git-wrapper.sh /usr/local/bin/git
-
-USER noteable
 
 # hadolint ignore=DL3006
 FROM main as gpu


### PR DESCRIPTION
## Describe your changes

Installs packages with the `noteable` user to avoid permission errors in follow-on installations.

Before:
![image](https://github.com/noteable-io/kernels/assets/7707189/82ca1b08-cdd4-44ca-bc3f-f98eb080a448)

After:
![image](https://github.com/noteable-io/kernels/assets/7707189/7216696a-0b60-4c4c-96c2-d51963b12210)



## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I am able to build images locally
- [ ] Has the issue it resolves been discussed with maintainers?
