### PR TITLE
[deno] add feature flag on `cargo install`

### DIFF
--- a/deno/base/1.37-dev/Dockerfile
+++ b/deno/base/1.37-dev/Dockerfile
@@ -41,6 +41,7 @@ ENV PATH="/srv/noteable/.cargo/bin:${PATH}"
 RUN cargo install \
     --git https://github.com/bartlomieju/deno \
     --rev 01ac23d431eed61308c27edad30d44040ae142cb \
+    --features __runtime_js_sources \
     deno
 
 COPY secrets_helper.sh /tmp/secrets_helper.sh
@@ -50,8 +51,6 @@ ENV HOME="/srv/noteable"
 
 WORKDIR /etc/noteable/project
 EXPOSE 50001-50005
-
-RUN cargo init
 
 ENTRYPOINT ["tini", "-g", "--"]
 CMD ["run.sh"]


### PR DESCRIPTION
## Describe your changes
Adds the `__runtime_js_sources` feature flag during `cargo install`, which seems to fix a lot of the random issues we had with `fetch` causing a `BadResource` error. Confirmed locally:

Before/after
![image](https://github.com/noteable-io/kernels/assets/7707189/51517080-a9be-4ee7-b879-77639bd468d7)
(ignore syntax highlighting on the right; that isn't caused by this PR)

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I am able to build images locally
- [X] Has the issue it resolves been discussed with maintainers?
