### PR TITLE
[deno] use installer and upgrade to canary build instead of building from the crate

### DIFF
--- a/deno/base/1.37-dev/Dockerfile
+++ b/deno/base/1.37-dev/Dockerfile
@@ -43,7 +43,6 @@ RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 ENV PATH="${DENO_INSTALL}/bin/:${PATH}"
 RUN deno upgrade --canary
 
-
 # the kernel needs the deno kernelspec discoverable locally before it can start
 # hadolint ignore=DL3059
 RUN deno --unstable jupyter --install

--- a/deno/base/1.37-dev/Dockerfile
+++ b/deno/base/1.37-dev/Dockerfile
@@ -34,15 +34,15 @@ RUN /usr/bin/apt-install Aptfile
 
 USER noteable
 
-ENV PATH="/srv/noteable/.cargo/bin:${PATH}"
+# use the deno installer and upgrade to the latest (canary) build
+# https://docs.deno.com/runtime/manual/references/contributing/release_schedule
+ENV DENO_INSTALL=/srv/noteable
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -fsSL https://deno.land/x/install/install.sh | sh
+# deno installs to `DENO_INSTALL/bin`, so we'll add to PATH for follow-on deno commands
+ENV PATH="${DENO_INSTALL}/bin/:${PATH}"
+RUN deno upgrade --canary
 
-# install deno from latest commit when jupyter2 branch was merged
-# TODO: update this once merged to main branch and use package install instead
-RUN cargo install \
-    --git https://github.com/denoland/deno \
-    --rev bf0760411336ce5ebb1c103f766c8154af478414 \
-    --features __runtime_js_sources \
-    deno
 
 # the kernel needs the deno kernelspec discoverable locally before it can start
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Describe your changes
- installation: https://docs.deno.com/runtime/manual/getting_started/installation
- release reference: https://docs.deno.com/runtime/manual/
- builds now take <30sec instead of 20min+ 🎉 

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I am able to build images locally
- [X] Has the issue it resolves been discussed with maintainers?
