### PR TITLE
don't replace spaces with periods in data frame conversion

### DIFF
--- a/r/noteable/.Rprofile
+++ b/r/noteable/.Rprofile
@@ -31,7 +31,10 @@ prepare_dex_content <- function(df) {
 
   # vectorized format (list of lists)
   #data = as.matrix.data.frame(t(df))
+
   # pandas df.to_dict("records") format
+  # NOTE: if we don't pass check.names=FALSE, columns with spaces will show periods instead, which will
+  # break the connection between the fields defined in `schema` and the keys in `data`
   data = as.data.frame.list(df, check.names=FALSE)
 
   list(

--- a/r/noteable/.Rprofile
+++ b/r/noteable/.Rprofile
@@ -32,7 +32,7 @@ prepare_dex_content <- function(df) {
   # vectorized format (list of lists)
   #data = as.matrix.data.frame(t(df))
   # pandas df.to_dict("records") format
-  data = as.data.frame.list(df)
+  data = as.data.frame.list(df, check.names=FALSE)
 
   list(
     schema = schema,


### PR DESCRIPTION
## Describe your changes

Fixes an issue where columns that included spaces would be replaced with periods, which breaks the connection between `schema` and the keys in `data` and results in empty columns in the DEX/grid view.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am able to build images locally
- [x] Has the issue it resolves been discussed with maintainers?
