### PR TITLE
include build of deno that includes jsx support

### DIFF
--- a/deno/base/1.37/Dockerfile
+++ b/deno/base/1.37/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 ENV PATH="${DENO_INSTALL}/bin/:${PATH}"
 RUN deno upgrade \
   --canary \
-  --version=48e695a2c89edad6e4880e7decfdb36d524f8279
+  --version=53248e9bb3123a1b684f3f9f744bb671dfa53bc1
 
 # the kernel needs the deno kernelspec discoverable locally before it can start
 # hadolint ignore=DL3059


### PR DESCRIPTION
Bring in https://github.com/denoland/deno/commit/53248e9bb3123a1b684f3f9f744bb671dfa53bc1 for inline JSX.

<img width="642" alt="image" src="https://github.com/noteable-io/kernels/assets/836375/dab2dab8-e512-452b-8880-78a118c8f396">

I'm a little quick on the draw here. The canary is still building, so I'll end up needing to kick this again in like 30 minutes or so.